### PR TITLE
A few tweaks to get it going

### DIFF
--- a/examples/hands/index02.html
+++ b/examples/hands/index02.html
@@ -15,8 +15,8 @@
   init: function () {
     var floor = this.el.sceneEl.querySelector('#rhand');
     var camera = this.el.sceneEl.querySelector('a-camera');
-    
-    
+
+
     floor.addEventListener('mousedown', function (evt) {
       //var pos = evt.detail.intersection.point;
       //var yy = camera.getAttribute('position').y;
@@ -52,7 +52,7 @@
     });
     floor.addEventListener('raycaster-intersection', function (evt) {
       //AFRAME.log(evt);
-	    
+
       console.log(evt);
     });
     floor.addEventListener('raycaster-intersected-cleared', function (evt) {
@@ -102,12 +102,13 @@
 		</a-camera>
 	  <!--a-entity id="lhand" laser-controls="left" mixin="controller"></a-entity-->
       <!--a-entity id="rhand" laser-controls="right" mixin="controller"></a-entity-->
-      <a-entity class="cube" mixin="cube" position="0 1 -1" material="color: red" class="myclickable"></a-entity>
-      <a-entity class="cube" mixin="cube" position="0 1.6 -1" material="color: red" class="myclickable"></a-entity>
-      <a-entity class="cube" mixin="cube" position="-1 1 -1" material="color: blue" class="myclickable"></a-entity>
-      <a-entity class="cube" mixin="cube" position="-1 1.6 -1" material="color: blue" class="myclickable"></a-entity>
-      <a-entity class="cube" mixin="cube" position="1 1 -1" material="color: green" class="myclickable"></a-entity>
-      <a-entity class="cube" mixin="cube" position="1 1.6 -1" material="color: green" class="myclickable"></a-entity>
+      <a-entity class="cube myclickable" mixin="cube" position="0 1 -1" material="color: red"></a-entity>
+      <!-- the class="cube" declaration was overriding the later class="myclickable". I combined them -->
+      <a-entity class="cube myclickable" mixin="cube" position="0 1.6 -1" material="color: red"></a-entity>
+      <a-entity class="cube myclickable" mixin="cube" position="-1 1 -1" material="color: blue"></a-entity>
+      <a-entity class="cube myclickable" mixin="cube" position="-1 1.6 -1" material="color: blue"></a-entity>
+      <a-entity class="cube myclickable" mixin="cube" position="1 1 -1" material="color: green"></a-entity>
+      <a-entity class="cube myclickable" mixin="cube" position="1 1.6 -1" material="color: green"></a-entity>
       <a-link href="../portals.html" title="Other Examples"
               image="#portals-preview"
               mixin="portal" hoverable

--- a/examples/hands/index02.html
+++ b/examples/hands/index02.html
@@ -97,7 +97,7 @@
         <a-mixin id="cube-dragover" material="wireframe: true;"></a-mixin>
         <img id="portals-preview" src="../assets/portals.jpg"></img>
       </a-assets>
-    <a-camera>
+    <a-camera position="0 0 0.5"> <!-- cursor was too close to center box and wasn't registering it -->
       <a-cursor id="rhand" cursor="fuse: false" mixin="controller" raycaster="objects: .myclickable;far: 100"></a-cursor>
 		</a-camera>
 	  <!--a-entity id="lhand" laser-controls="left" mixin="controller"></a-entity-->

--- a/examples/hands/index02.html
+++ b/examples/hands/index02.html
@@ -29,7 +29,6 @@
       console.log(evt);
     });
     floor.addEventListener('mouseenter', function (evt) {
-	    evt.detail.intersectedEl.addState('collided');
 	    floor.emit('hit', {el:evt.detail.intersectedEl}) // the emit method wraps the second argument in event.detail automatically
       //AFRAME.log(evt);
       console.log(evt);
@@ -85,7 +84,11 @@
                  super-hands
                  sphere-collider="objects: .cube, a-link"></a-mixin-->
 	      <a-mixin id="controller"
-                 super-hands></a-mixin>
+                 super-hands="colliderState: cursor-hovered">
+          <!-- it's important that the state gets removed when the collision
+               ends, so we'll just tell super-hands to track the cursor state
+               instead of adding collided manually -->
+        </a-mixin>
         <a-mixin id="cube" geometry="primitive: box; width: 0.5; height: 0.5; depth: 0.5"
                  hoverable grabbable stretchable drag-droppable
                  shadow

--- a/examples/hands/index02.html
+++ b/examples/hands/index02.html
@@ -84,10 +84,17 @@
                  super-hands
                  sphere-collider="objects: .cube, a-link"></a-mixin-->
 	      <a-mixin id="controller"
-                 super-hands="colliderState: cursor-hovered">
+                 super-hands="colliderState: cursor-hovered;
+                    grabStartButtons: mousedown, trackpaddown, triggerdown;
+                    grabEndButtons: mouseup, trackpaddup, triggerup;
+                    dragDropStartButtons: mousedown, trackpaddown, triggerdown;
+                    dragDropEndButtons: mouseup, trackpaddup, triggerup;">
           <!-- it's important that the state gets removed when the collision
                ends, so we'll just tell super-hands to track the cursor state
                instead of adding collided manually -->
+          <!-- to get grabbable working with the mouse, we just need to change
+               the button mappings. The default mappings should already work
+               the daydream trackpad button, though -->
         </a-mixin>
         <a-mixin id="cube" geometry="primitive: box; width: 0.5; height: 0.5; depth: 0.5"
                  hoverable grabbable stretchable drag-droppable

--- a/examples/hands/index02.html
+++ b/examples/hands/index02.html
@@ -30,7 +30,7 @@
     });
     floor.addEventListener('mouseenter', function (evt) {
 	    evt.detail.intersectedEl.addState('collided');
-	    floor.emit('hit', {detail:{el:evt.detail.intersectedEl}})
+	    floor.emit('hit', {el:evt.detail.intersectedEl}) // the emit method wraps the second argument in event.detail automatically
       //AFRAME.log(evt);
       console.log(evt);
     });


### PR DESCRIPTION
You are on the right track; just needed some small changes

1. There were two class declarations on the box entities, so your "myclickable" class was getting ignored, preventing the raycaster from finding the boxes
2. A-Frame puts the cursor some distance in front of the camera, which was too close the to top red box, preventing the raycaster from seeing it
3. `emit` automatically wraps the argument inside a `details` object, so it was getting double nested

This is enough to start seeing the boxes take on the `'hovered'` state form `hoverable`, but there are still more tweaks needed